### PR TITLE
Adaptive streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Intel_Edison/Debian/.vagrant
 Nvidia_JTX1/Ubuntu/jetpack_download
 Nvidia_JTX1/Ubuntu/JetPack-L4T-2.3.1-linux-x64.run
 Nvidia_JTX1/Ubuntu/.vagrant
+Common/Ubuntu/adaptive-streaming

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Common/Ubuntu/adaptitve-streaming"]
+	path = Common/Ubuntu/adaptitve-streaming
+	url = https://github.com/shortstheory/adaptive-streaming

--- a/RPI2/Raspbian/9_setup_adaptive_streaming.sh
+++ b/RPI2/Raspbian/9_setup_adaptive_streaming.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# RPi2 setup script for use as companion computer
+
+if [ $(id -u) -ne 0 ]; then
+   echo >&2 "Must be run as root"
+   exit 1
+fi
+
+set -e
+set -x
+
+#GStreamer deps
+apt install libgstreamer-plugins-base1.0* libgstreamer1.0-dev libgstrtspserver-1.0-dev
+
+#For building
+pip3 install meson
+apt install ninja-build
+
+cd
+git submodule update --init --recursive
+cd Common/Ubuntu/adaptive-streaming/
+meson build
+cd build
+ninja install

--- a/RPI2/Raspbian/9_setup_adaptive_streaming.sh
+++ b/RPI2/Raspbian/9_setup_adaptive_streaming.sh
@@ -18,7 +18,7 @@ pip3 install meson
 apt install ninja-build
 
 cd
-git submodule update --init --recursive
+git submodule foreach --recursive git pull
 cd Common/Ubuntu/adaptive-streaming/
 meson build
 cd build

--- a/RPI2/Raspbian/start_adaptive_stream
+++ b/RPI2/Raspbian/start_adaptive_stream
@@ -14,8 +14,13 @@ if test -z "$STREAM_TO_IP"; then
 fi
 shift
 
+
+# Load the RPi Camera V4L2 Driver
+sudo modprobe bcm2835-v4l2
+
 # For getting a stream which automatically adjusts the quality according to the 
 # connection quality. Use the following gst-launch command to make it work:
-# gst-launch-1.0 -v rtpbin latency=0 name=rtpbin udpsrc caps="application/x-rtp,media=(string)video,clock-rate=(int)90000,encoding-name=(string)H264,payload=96" port=5000 !  rtpbin.recv_rtp_sink_0 rtpbin. ! rtph264depay ! h264parse ! avdec_h264 ! autovideosink udpsrc port=5001 ! rtpbin.recv_rtcp_sink_0 rtpbin.send_rtcp_src_0 ! udpsink port=5005 sync=false async=false host=10.0.1.128
+# gst-launch-1.0 -v rtpbin latency=0 name=rtpbin udpsrc caps="application/x-rtp,media=(string)video,clock-rate=(int)90000,encoding-name=(string)H264,payload=96" port=5000 !  rtpbin.recv_rtp_sink_0 rtpbin. ! rtph264depay ! h264parse ! avdec_h264 ! autovideosink udpsrc port=5001 ! rtpbin.recv_rtcp_sink_0 rtpbin.send_rtcp_src_0 ! udpsink port=5001 sync=false async=false host=10.0.1.128
+# By default, port 5000 is used for RTP and port 5001 is used for RTCP
 
-adaptive_streaming /dev/video0 $STREAM_TO_PORT
+adaptive_streaming /dev/video0 $STREAM_TO_IP

--- a/RPI2/Raspbian/start_adaptive_stream
+++ b/RPI2/Raspbian/start_adaptive_stream
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+set -x
+
+function fail() {
+    echo "Fail: $*"
+    exit 1
+}
+
+STREAM_TO_IP=$1
+if test -z "$STREAM_TO_IP"; then
+    fail "Need an IP to stream to"
+fi
+shift
+
+# For getting a stream which automatically adjusts the quality according to the 
+# connection quality. Use the following gst-launch command to make it work:
+# gst-launch-1.0 -v rtpbin latency=0 name=rtpbin udpsrc caps="application/x-rtp,media=(string)video,clock-rate=(int)90000,encoding-name=(string)H264,payload=96" port=5000 !  rtpbin.recv_rtp_sink_0 rtpbin. ! rtph264depay ! h264parse ! avdec_h264 ! autovideosink udpsrc port=5001 ! rtpbin.recv_rtcp_sink_0 rtpbin.send_rtcp_src_0 ! udpsink port=5005 sync=false async=false host=10.0.1.128
+
+adaptive_streaming /dev/video0 $STREAM_TO_PORT


### PR DESCRIPTION
Introducing the Flexible Video GSoC 2018 project for APSync. These commits add a git submodule for the [adaptive-streaming](https://github.com/shortstheory/adaptive-streaming) project and contains instructions on how to start the stream.
 