### PR TITLE
APStreamline in companion

### DIFF
--- a/Common/Ubuntu/apstreamline/install_apstreamline
+++ b/Common/Ubuntu/apstreamline/install_apstreamline
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# install APStreamline to provide video streaming
+
+if [ $(id -u) -ne 0 ]; then
+   echo >&2 "Must be run as root"
+   exit 1
+fi
+
+set -e
+set -x
+
+apt-get install ninja-build libgstreamer-plugins-base1.0* libgstreamer1.0-dev libgstrtspserver-1.0-dev gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly python3-pip
+modprobe bcm2835-v4l2
+echo 'bcm2835-v4l2' >> /etc/modules
+
+#For building
+pip3 install meson
+
+sudo -u $NORMAL_USER -H bash <<EOF
+set -e
+set -x
+
+pushd ~/GitHub
+ git clone https://github.com/shortstheory/adaptive-streaming.git APStreamline
+ pushd APStreamline
+  meson build
+  pushd build
+   meson configure -Dprefix=$HOME/start_apstreamline/
+   time ninja
+   sudo ninja install
+  popd
+ popd
+popd
+
+EOF

--- a/Common/Ubuntu/apweb/install_apweb
+++ b/Common/Ubuntu/apweb/install_apweb
@@ -32,9 +32,8 @@ cp autostart_apweb.sh \$APWEB_HOME/
 
 pushd ~/GitHub
  rm -rf APWeb
- git clone --recurse-submodules https://github.com/peterbarker/APWeb
+ git clone --recurse-submodules -b video_streaming https://github.com/shortstheory/APWeb.git
  pushd APWeb
-  git checkout apsync
   git submodule update --init
   time (make | cat)
   cp web_server \$APWEB_HOME

--- a/Common/Ubuntu/apweb/start_apweb.sh
+++ b/Common/Ubuntu/apweb/start_apweb.sh
@@ -5,5 +5,5 @@
 
 set -e
 set -x
-
+export PATH="$PATH:/home/apsync/start_apstreamline/bin"
 ./web_server -p 80 -f 14755

--- a/Common/Ubuntu/cherrypy/install
+++ b/Common/Ubuntu/cherrypy/install
@@ -13,7 +13,7 @@ fi
 set -e
 set -x
 
-pip install cherrypy jinja2
+pip install cherrypy==10.2.1 jinja2
 
 sudo -u $NORMAL_USER -H bash <<'EOF'
 set -e

--- a/RPI2/Raspbian/1_create_base_image.txt
+++ b/RPI2/Raspbian/1_create_base_image.txt
@@ -76,6 +76,7 @@ time sudo ./8_red_balloon_finder.sh || echo "Failed" # 18s
 time sudo ./5_setup_mavproxy.sh # 2s
 time sudo ./install_pymavlink # new version required for apweb # 3m
 time sudo ./install_apweb # 2m33s
+time sudo ./install_apstreamline
 time sudo ./resize_filesystem_on_next_boot
 popd
 

--- a/RPI2/Raspbian/install_apstreamline
+++ b/RPI2/Raspbian/install_apstreamline
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ $(id -u) -ne 0 ]; then
+   echo >&2 "Must be run as root"
+   exit 1
+fi
+
+set -e
+set -x
+
+. config.env
+
+pushd ../../Common/Ubuntu/apstreamline
+ ./install_apstreamline
+popd


### PR DESCRIPTION
This PR adds the flexible video streaming project called APStreamline: https://github.com/shortstheory/adaptive-streaming

It still retains the classical UDP streaming approach using the cherrypy webserver though it might cause issues if both are used at the same time.