### PR TITLE
Common/Ubuntu: update librealsense version to 2.36.0

### DIFF
--- a/Common/Ubuntu/librealsense/install_librealsense.sh
+++ b/Common/Ubuntu/librealsense/install_librealsense.sh
@@ -11,7 +11,7 @@ echo "Build latest version of librealsense"
 tput sgr0
 
 LIBREALSENSE_DIRECTORY=${HOME}/GitHub/librealsense
-LIBREALSENSE_VERSION=v2.35.2
+LIBREALSENSE_VERSION=v2.36.0
 INSTALL_DIR=$PWD
 NVCC_PATH=/usr/local/cuda-10.0/bin/nvcc
 

--- a/Common/Ubuntu/librealsense/install_librealsense.sh
+++ b/Common/Ubuntu/librealsense/install_librealsense.sh
@@ -3,8 +3,6 @@
 # Copyright (c) 2016-19 Jetsonhacks
 # MIT License
 
-# Jetson Nano; L4T 32.2.3
-
 set -e
 set -x
 


### PR DESCRIPTION
Upgrading to the latest official / stable release of the librealsense libraries