### PR TITLE
Common/Ubuntu: fix dxx.service typo

### DIFF
--- a/Common/Ubuntu/librealsense/d4xx.service
+++ b/Common/Ubuntu/librealsense/d4xx.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Realsense D4xx Service
-After==multi-user.target
+After=multi-user.target
 StartLimitIntervalSec=0
 Conflicts=
 


### PR DESCRIPTION
@rmackay9 I think this is a typo. I confirmed yesterday that the script will not start when the typo of t265.service in the image of 2020/7/3 is modified. It's a little strange.